### PR TITLE
Cleaner signup form for signed-out users. 

### DIFF
--- a/Twipster For Chrome/twipster.css
+++ b/Twipster For Chrome/twipster.css
@@ -225,8 +225,8 @@ padding-bottom: 80px !important;
   color: #fff !important;
 }
 
-.signup-call-out div.flex-module div.holding {display: inline-block;}
-.signup-call-out div.flex-module div.holding input {width: 200px;}
+.signup-call-out div.flex-module div.holding {display: inline-block !important;}
+.signup-call-out div.flex-module div.holding input {width: 200px !important;}
 
 /*  ----------------------------------------------------------------
     Modals */

--- a/Twipster.safariextension/twipster.css
+++ b/Twipster.safariextension/twipster.css
@@ -225,8 +225,8 @@ padding-bottom: 80px !important;
   color: #fff !important;
 }
 
-.signup-call-out div.flex-module div.holding {display: inline-block;}
-.signup-call-out div.flex-module div.holding input {width: 200px;}
+.signup-call-out div.flex-module div.holding {display: inline-block !important;}
+.signup-call-out div.flex-module div.holding input {width: 200px !important;}
 
 /*  ----------------------------------------------------------------
     Modals */

--- a/twipster.css
+++ b/twipster.css
@@ -225,8 +225,8 @@ padding-bottom: 80px !important;
   color: #fff !important;
 }
 
-.signup-call-out div.flex-module div.holding {display: inline-block;}
-.signup-call-out div.flex-module div.holding input {width: 200px;}
+.signup-call-out div.flex-module div.holding {display: inline-block !important;}
+.signup-call-out div.flex-module div.holding input {width: 200px !important;}
 
 /*  ----------------------------------------------------------------
     Modals */


### PR DESCRIPTION
Cleaner signup form on profile pages. Just changing the placeholder divs for the form element to display as an inline-block, and reducing the width of the form inputs to 200px. 

![Cleaner Signup form](https://f.cloud.github.com/assets/104119/336029/92cbeed6-9c9c-11e2-88ea-b8ac0a62b88a.PNG)
