### PR TITLE
Fix for max-height on quoted tweets

### DIFF
--- a/chrome/src/twipster.css
+++ b/chrome/src/twipster.css
@@ -139,3 +139,7 @@ body.ProfilePage {
   margin: 0 auto !important;
 }
 
+/* Quoted text */
+.QuoteTweet-text {
+  max-height: 90px !important;
+}

--- a/safari/Twipster.safariextension/twipster.css
+++ b/safari/Twipster.safariextension/twipster.css
@@ -139,3 +139,7 @@ body.ProfilePage {
   margin: 0 auto !important;
 }
 
+/* Quoted text */
+.QuoteTweet-text {
+  max-height: 90px !important;
+}

--- a/src/twipster.css
+++ b/src/twipster.css
@@ -139,3 +139,7 @@ body.ProfilePage {
   margin: 0 auto !important;
 }
 
+/* Quoted text */
+.QuoteTweet-text {
+  max-height: 90px !important;
+}


### PR DESCRIPTION
Fix for this behavior of quoted tweets:

Before:
![](http://dl.dpeck.net/cRPuTT+)

After:
![](http://dl.dpeck.net/5krNee+)